### PR TITLE
Put inline roll manager button after the skill check element.

### DIFF
--- a/scripts/module.js
+++ b/scripts/module.js
@@ -54,7 +54,7 @@ Hooks.on("renderApplication", (app, html, data) => {
         // Append the icon to the button
         button.append(icon);
         // Append the button to the skill check element
-        skillCheckElement.append(button);
+        button.insertAfter(skillCheckElement);
         // Extract the skill type and DC from the inline check button
         const skillType = skillCheckElement.attr('data-pf2-check');
         const dc = parseInt(skillCheckElement.attr('data-pf2-dc'), 10);


### PR DESCRIPTION
Fixes #24.

It seems like foundry just copies the element from the skill check into the chat log message. As such, placing the roll manager button next to the skill check rather than inside of it fixes the issue.