### PR TITLE
Add "forced" blind GM rolls.

### DIFF
--- a/scripts/module.js
+++ b/scripts/module.js
@@ -661,7 +661,7 @@ function createContainer() {
     return container;
 }
 
-async function createHeadingWithDC(skillsToRoll, dc, showDCForRoll) {
+async function createHeadingWithDC(skillsToRoll, dc, isBlindGM) {
     // Use showDCForRoll parameter to decide whether to include DC in heading text
     let formattedSkills;
     if (skillsToRoll.length === 1) {
@@ -674,8 +674,7 @@ async function createHeadingWithDC(skillsToRoll, dc, showDCForRoll) {
         formattedSkills = skillsToRoll.join(', '); // For more than 3 skills, if needed.
     }
 
-    showDCForRoll = await game.settings.get('pf2e-roll-manager', 'showDCForRoll');
-
+    const showDCForRoll = await game.settings.get('pf2e-roll-manager', 'showDCForRoll') && !isBlindGM;
 
     const heading = document.createElement('h1');
     if (showDCForRoll === true) {
@@ -691,8 +690,8 @@ async function createHeadingWithDC(skillsToRoll, dc, showDCForRoll) {
     return heading;
 }
 
-async function createHeadingWrapper(skillsToRoll, dc) {
-    return await createHeadingWithDC(skillsToRoll, dc);
+async function createHeadingWrapper(skillsToRoll, dc, isBlindGM) {
+    return await createHeadingWithDC(skillsToRoll, dc, isBlindGM);
 }
 
 function createCharacterBox(character, skillsToRoll, dc, isBlindGM, index, characterBoxes, resultsSummary) {
@@ -960,7 +959,7 @@ function sendResultsToGM() {
 async function generateCharacterRollBoxes(selectedCharacters, skillsToRoll, dc, isBlindGM) {
     const overlay = createOverlay();
     const container = createContainer();
-    const heading = await createHeadingWrapper(skillsToRoll, dc); // Await the promise
+    const heading = await createHeadingWrapper(skillsToRoll, dc, isBlindGM); // Await the promise
     container.appendChild(heading);
 
     const boxesContainer = document.createElement('div');

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -205,6 +205,7 @@ function renderRollManagerDialog(selectedTokens = [], preSelectedCharacterIds = 
         content: dialogContent,
         buttons: {
             roll: createRollButton(preSelectedCharacterIds, preSelectedSkills, preSelectedDC, selectedTokens),
+            blindRoll: createRollButton(preSelectedCharacterIds, preSelectedSkills, preSelectedDC, selectedTokens, true),
             rollFlat: createFlatCheckButton(preSelectedCharacterIds, preSelectedDC, selectedTokens),
             cancel: {
                 icon: '<i class="fas fa-times"></i>',
@@ -351,14 +352,13 @@ function buildStandardDcButtons() {
     `).join('');
 }
 
-function createRollButton(preSelectedCharacterIds, preSelectedSkills, preSelectedDC, selectedTokens) {
+function createRollButton(preSelectedCharacterIds, preSelectedSkills, preSelectedDC, selectedTokens, isBlindGM = false) {
     return {
-        icon: '<i class="fas fa-dice-d20"></i>',
-        label: 'Roll',
+        icon: `<i class="fas ${isBlindGM ? 'fa-eye' : 'fa-dice-d20'}"></i>`,
+        label: isBlindGM ? 'Roll Blind GM' : 'Roll',
         callback: (html) => {
             const selectedSkills = html.find('.skill-button.selected').map((_, el) => el.dataset.skill).get();
             const dc = parseInt(html.find('#dc-input').val(), 10);  // Get the updated DC value
-            const isBlindGM = html.find('[name="blindGM"]').is(':checked'); // Get the value of the blind GM checkbox
             const selectedCharacterIds = html.find('[name="character"]:checked').map((_, el) => el.value).get();
             if (selectedSkills.length === 0) {
                 ui.notifications.warn("Please select at least one skill or save to roll.");
@@ -758,11 +758,14 @@ function createCharacterBox(character, skillsToRoll, dc, isBlindGM, index, chara
     });
     box.appendChild(skillSelect);
 
-    const rollButton = document.createElement('button');
-    rollButton.textContent = 'Roll';
-    rollButton.style.display = 'block';
-    rollButton.style.margin = '10px auto';
-    box.appendChild(rollButton);
+    let rollButton;
+    if (!isBlindGM) {
+        rollButton = document.createElement('button');
+        rollButton.textContent = 'Roll';
+        rollButton.style.display = 'block';
+        rollButton.style.margin = '10px auto';
+        box.appendChild(rollButton);
+    }
 
     const rollBlindButton = document.createElement('button');
     rollBlindButton.textContent = 'Roll Blind GM';
@@ -788,7 +791,9 @@ function createCharacterBox(character, skillsToRoll, dc, isBlindGM, index, chara
         box.classList.add('visible');
     }, 500 + index * 200);
 
-    addRollButtonEventListener(rollButton, character, skillSelect, box, dc, characterBoxes, resultsSummary);
+    if (!isBlindGM) {
+        addRollButtonEventListener(rollButton, character, skillSelect, box, dc, characterBoxes, resultsSummary);
+    }
     addRollBlindButtonEventListener(rollBlindButton, character, skillSelect, box, dc, characterBoxes, resultsSummary);
 
     return box;

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -215,28 +215,8 @@ function renderRollManagerDialog(selectedTokens = [], preSelectedCharacterIds = 
         default: 'roll',
         render: (html) => {
             setupDialog(html, selectedTokens, initialDC, levelBasedDC);
-
-            // Add event listener to checkbox using jQuery
-            html.find('#hide-dc-checkbox').on('change', function () {
-                const showDCForRoll = $(this).prop('checked');
-                game.settings.set('pf2e-roll-manager', 'showDCForRoll', showDCForRoll);
-                // Update the heading with the new showDCForRoll value
-                updateHeadingWithDC(selectedTokens, initialDC, levelBasedDC, showDCForRoll);
-            });
         }
     }, {width: 620, height: 860}).render(true);
-}
-
-async function updateHeadingWithDC(selectedTokens, initialDC, levelBasedDC, showDCForRoll) {
-    // Retrieve skills to roll and DC values here
-    const skillsToRoll = []; // Assuming you get the skills from somewhere
-    const dc = 0; // Assuming you get the DC from somewhere
-
-    const heading = await createHeadingWithDC(skillsToRoll, dc, showDCForRoll);
-
-    // Update the heading in your UI
-    // Example: document.getElementById('headingContainer').innerHTML = '';
-    // Example: document.getElementById('headingContainer').appendChild(heading);
 }
 
 function buildCharacterSelection(users, preSelectedCharacterIds, characterLevels) {
@@ -308,7 +288,6 @@ function buildDialogContent(preSelectedSkills, initialDC, characterSelection) {
         <div><hr></div>
         <!-- Additional Options Section -->
         <div class="additional-options">
-<!--            <label><input type="checkbox" id="hide-dc-checkbox" name="hide-dc"> Hide DC</label>-->
         </div>
         <div><hr></div>
         <div class="kofi-donation">


### PR DESCRIPTION
Fixes #7

This doesn't prevent the player from changing to a public roll in the roll dialog still but it's at least signals to the player that the roll is intended to be blind. I'm not sure it's worth trying to force it to be blind no matter what.